### PR TITLE
gacha_charactersテーブルを更新

### DIFF
--- a/mysql/ddl.sql
+++ b/mysql/ddl.sql
@@ -10,60 +10,101 @@ CREATE TABLE IF NOT EXISTS `game_user`.`users`(
 
 DROP TABLE IF EXISTS `game_user`.`rarities`;
 CREATE TABLE IF NOT EXISTS `game_user`.`rarities`(
-  `rarity_id` INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+  `id` INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
   `rarity_name` VARCHAR(32) NOT NULL,
-  `weight` INT NOT NULL
+  `weight` INT NOT NULL,
+  `HPup` INT NOT NULL
 );
 
-INSERT INTO rarities(rarity_name, weight) VALUES ('SR', 1);
-INSERT INTO rarities(rarity_name, weight) VALUES ('R', 5);
-INSERT INTO rarities(rarity_name, weight) VALUES ('N', 14);
+INSERT INTO rarities(rarity_name, weight, HPup) VALUES ('SR', 1, 1000);
+INSERT INTO rarities(rarity_name, weight, HPup) VALUES ('R', 5, 500);
+INSERT INTO rarities(rarity_name, weight, HPup) VALUES ('N', 14, 0);
 
-DROP TABLE IF EXISTS `game_user`.`gacha_characters`;
-CREATE TABLE IF NOT EXISTS `game_user`.`gacha_characters`(
-  `character_id` CHAR(36) PRIMARY KEY NOT NULL,
-  `gacha_id` INT NOT NULL,
-  `rarity_id` INT NOT NULL,
+DROP TABLE IF EXISTS `game_user`.`characters`;
+CREATE TABLE IF NOT EXISTS `game_user`.`characters`(
+  `id` INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
   `character_name` VARCHAR(32) NOT NULL,
   `HP` INT NOT NULL
 );
 
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 1, "Mercury", 1200);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 2, "Venus", 850);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 2, "Earth", 800);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 2, "Mars", 750);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 3, "Jupiter", 450);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 3, "Saturn", 425);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 3, "Uranus", 400);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 3, "Neptune", 400);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 3, "Pluto", 375);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 1, 3, "Sun", 350);
+INSERT INTO characters(character_name, HP) VALUES ("Mercury", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Venus", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Earth", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Mars", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Jupiter", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Saturn", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Uranus", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Neptune", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Pluto", 1000);
+INSERT INTO characters(character_name, HP) VALUES ("Sun", 1000);
 
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 3, "Mercury", 450);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 3, "Venus", 400);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 3, "Earth", 350);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 1, "Mars", 1250);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 2, "Jupiter", 850);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 2, "Saturn", 800);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 2, "Uranus", 750);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 3, "Neptune", 425);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 3, "Pluto", 400);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 2, 3, "Sun", 375);
+DROP TABLE IF EXISTS `game_user`.`gachas`;
+CREATE TABLE IF NOT EXISTS `game_user`.`gachas`(
+  `id` INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+  `gacha_name` VARCHAR(32) NOT NULL
+);
 
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 3, "Mercury", 450);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 3, "Venus", 425);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 3, "Earth", 400);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 3, "Mars", 400);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 3, "Jupiter", 375);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 3, "Saturn", 350);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 1, "Uranus", 1150);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 2, "Neptune", 850);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 2, "Pluto", 800);
-INSERT INTO gacha_characters(character_id, gacha_id, rarity_id, character_name, HP) VALUES (UUID(), 3, 2, "Sun", 750);
+INSERT INTO gachas(gacha_name) VALUES ("Gacha_A");
+INSERT INTO gachas(gacha_name) VALUES ("Gacha_B");
+INSERT INTO gachas(gacha_name) VALUES ("Gacha_C");
+
+DROP TABLE IF EXISTS `game_user`.`gacha_characters`;
+CREATE TABLE IF NOT EXISTS `game_user`.`gacha_characters`(
+  `gacha_character_id` CHAR(36) PRIMARY KEY NOT NULL,
+  `gacha_id` INT NOT NULL,
+  `character_id` INT NOT NULL,
+  `rarity_id` INT NOT NULL,
+  `HP` INT NOT NULL
+);
+
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 1, 1, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 2, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 3, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 4, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 5, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 6, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 7, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 8, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 9, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 10, 3, 0);
+
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 1, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 2, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 3, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 4, 1, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 5, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 6, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 7, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 8, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 9, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 10, 3, 0);
+
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 1, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 2, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 3, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 4, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 5, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 6, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 7, 1, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 8, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 9, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 10, 2, 0);
+
+CREATE VIEW character_HP AS
+SELECT gacha_characters.gacha_character_id, rarities.HPup + characters.HP AS HP
+FROM gacha_characters
+JOIN characters
+ON gacha_characters.character_id = characters.id
+JOIN rarities
+ON gacha_characters.rarity_id = rarities.id;
+
+UPDATE gacha_characters, character_HP
+SET gacha_characters.HP = character_HP.HP
+WHERE gacha_characters.gacha_character_id = character_HP.gacha_character_id;
 
 DROP TABLE IF EXISTS `game_user`.`user_characters`;
 CREATE TABLE IF NOT EXISTS `game_user`.`user_characters`(
   `user_character_id` CHAR(36) PRIMARY KEY NOT NULL,
   `user_id` VARCHAR(36) NOT NULL,
-  `character_id` VARCHAR(36) NOT NULL
+  `gacha_character_id` VARCHAR(36) NOT NULL
 );


### PR DESCRIPTION
## 変更の概要

### gacha_charactersテーブルを更新
これまではgacha_charactersテーブルの中でキャラクター名やHPを定義していたが、ここでgachasテーブルとcharactersテーブルを新たに加えた。gachasテーブルの中ではそれぞれのガチャの名前（Gacha_A、Gacha_B、Gacha_C）を定義し、charactersテーブルの中ではそれぞれのキャラクターの名前と基礎HPを定義した。gachasテーブルとcharactersテーブルの主キーであるそれぞれのテーブルのIDをgacha_charactersテーブルの中に外部キーとして取り入れ、gacha_charactersテーブルの主キーはUUIDで作ることとした。このgacha_charactersテーブルの主キーであるUUIDが、api内のdrawGacha関数やgetCharacterList関数で返されるresultsやcharactersのcharacterIDである。また、それぞれのガチャのキャラクターのHPが、各レア度に応じて変わるようにcharacter_HPというビューを作り、gacha_charactersテーブルのHPを更新した。

### 乱数のシード生成の方法を変更
drawGacha関数内で用いるdrawGachaCharacterIds関数において、シード値を現在のUNIX時間を用いる方式からcrypto/randパッケージのInt関数を用いる方式に切り替えた。UNIX時間はある範囲に限定されるが、Int関数は限定されないからである。

### RespondWithJSONとErrorResponseをErrorResponseに統一
エラーが起きた時の処理において、RespondWithJSONとErrorResponseの二つの同じ処理をする関数を使っていたので、RespondWithJSONを削除し、ErrorResponseに統一した。

### getIdContains関数の追加
getIdContains関数によりdrawGacha関数にてユーザが存在しないガチャのIDを入れた時にエラーが返るようにした。また、ガチャを引く回数にマイナスの数字を入れた時にエラーが返るようにした。